### PR TITLE
Manifest V2 廃止対応

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Rational Modulo Converter",
   "short_name": "RATMOD",
   "version": "0.0.1",


### PR DESCRIPTION
Manifest V2 のサポートが終了して動作しなくなっていたので、V3 に上げてみました。
V2 に依存した部分は無いためバージョン変更のみ。

※以下ページを参考
https://zenn.dev/katoaki/articles/4e7548b533d7b3