### PR TITLE
HTMLタグ内の数字への誤爆回避

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -19,21 +19,34 @@ const add_rational_expression = function(original, mod){
     original += '*';
     var buffer = "";
     var res = "";
+    var tagParsing = false;
     for(var i = 0;i < original.length;i++){
         var c = original[i];
-        if('0' <= c && c <= '9'){
-            buffer += c;
+        if('<' == c) {
+            tagParsing = true;
+            res += buffer;
+            buffer = "";
         }
-        else{
-            if(buffer != ""){
-                var num = parseInt(buffer);
-                if(num < mod && num * num * 2 > mod){
-                    w = reconstruct(num, mod);
-                    buffer += ' <font color="red">' + w[0] + "/" + w[1] + "</font> ";
-                }
-                res += buffer;
-                buffer = "";
+        else if('>' == c) {
+            tagParsing = false;
+        }
+        if(!tagParsing) {
+            if('0' <= c && c <= '9'){
+                buffer += c;
             }
+            else{
+                if(buffer != ""){
+                    var num = parseInt(buffer);
+                    if(num < mod && num * num * 2 > mod){
+                        w = reconstruct(num, mod);
+                        buffer += ' <font color="red">' + w[0] + "/" + w[1] + "</font> ";
+                    }
+                    res += buffer;
+                    buffer = "";
+                }
+                res += c;
+            }
+        }else {
             res += c;
         }
     }


### PR DESCRIPTION
以下キャプチャのようにタグ内の数字に誤爆して HTML が壊れていたため、<～>内の処理はスキップするような変更です。

![スクリーンショット 2023-05-06 141006](https://user-images.githubusercontent.com/1593516/236601256-88bf4582-af66-401f-ac81-1b4566036ee2.png)
